### PR TITLE
7주차미션_데이빗

### DIFF
--- a/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/BlogApplication.java
+++ b/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/BlogApplication.java
@@ -1,0 +1,13 @@
+package umc.blog;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BlogApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(BlogApplication.class, args);
+	}
+
+}

--- a/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/controller/PostController.java
+++ b/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/controller/PostController.java
@@ -1,0 +1,70 @@
+package umc.blog.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import umc.blog.dto.PostDto;
+import umc.blog.dto.PostEditDto;
+import umc.blog.exception.InputValidateException;
+import umc.blog.exception.ExceptionResponse;
+import umc.blog.exception.TargetNotFoundException;
+import umc.blog.service.PostService;
+
+@RestController
+@RequestMapping("/post")
+public class PostController {
+    private final PostService postService;
+
+    @Autowired
+    public PostController(PostService postService) {
+        this.postService = postService;
+    }
+
+    // 특정 글 조회 (id)
+    @GetMapping("/{id}")
+    ResponseEntity<?> findPostById(@PathVariable Long id) {
+        try {
+            return ResponseEntity.ok(postService.findOne(id));
+        } catch (TargetNotFoundException e) {
+            return errorMessage(e.getMessage());
+        }
+    }
+
+    // 글 생성
+    @PostMapping
+    ResponseEntity<?> createPost(@RequestBody PostDto postDto) {
+        try {
+            return ResponseEntity.ok(postService.write(postDto));
+        } catch (InputValidateException e) {
+            return errorMessage(e.getMessage());
+        }
+    }
+
+    // 글 수정
+    @PutMapping("/{id}")
+    ResponseEntity<?> editPost(@PathVariable Long id, @RequestBody PostEditDto editDto) {
+        try {
+            return ResponseEntity.ok(postService.edit(id, editDto));
+        } catch (InputValidateException | TargetNotFoundException e) {
+            return errorMessage(e.getMessage());
+        }
+    }
+
+    // 글 삭제
+    @DeleteMapping("/{id}")
+    ResponseEntity<?> deletePost(@PathVariable Long id) {
+        try {
+            postService.delete(id);
+            return ResponseEntity.status(HttpStatus.OK).body("글 삭제 완료");
+        } catch (TargetNotFoundException e) {
+            return errorMessage(e.getMessage());
+        }
+    }
+
+    private static ResponseEntity<ExceptionResponse> errorMessage(String e) {
+        ExceptionResponse exceptionResponse = new ExceptionResponse(e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(exceptionResponse);
+    }
+}

--- a/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/dto/PostDto.java
+++ b/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/dto/PostDto.java
@@ -1,0 +1,13 @@
+package umc.blog.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@RequiredArgsConstructor
+@Getter
+@Setter
+public class PostDto {
+    private String title;
+    private String content;
+}

--- a/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/dto/PostEditDto.java
+++ b/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/dto/PostEditDto.java
@@ -1,0 +1,13 @@
+package umc.blog.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@RequiredArgsConstructor
+@Getter
+@Setter
+public class PostEditDto {
+    private String title;
+    private String content;
+}

--- a/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/entity/Post.java
+++ b/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/entity/Post.java
@@ -1,0 +1,23 @@
+package umc.blog.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Post {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    Long id;
+
+    String writer;
+
+    String title;
+
+    String content;
+}

--- a/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/exception/ExceptionResponse.java
+++ b/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/exception/ExceptionResponse.java
@@ -1,0 +1,13 @@
+package umc.blog.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ExceptionResponse {
+
+    private String message;
+}

--- a/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/exception/InputValidateException.java
+++ b/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/exception/InputValidateException.java
@@ -1,0 +1,10 @@
+package umc.blog.exception;
+
+public class InputValidateException extends RuntimeException {
+    public InputValidateException() {
+    }
+
+    public InputValidateException(String message) {
+        super(message);
+    }
+}

--- a/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/exception/TargetNotFoundException.java
+++ b/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/exception/TargetNotFoundException.java
@@ -1,0 +1,10 @@
+package umc.blog.exception;
+
+public class TargetNotFoundException extends RuntimeException {
+    public TargetNotFoundException() {
+    }
+
+    public TargetNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/repository/PostRepository.java
+++ b/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package umc.blog.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.blog.entity.Post;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/service/PostService.java
+++ b/데이빗_최현준/7주차 미션/blog/src/main/java/umc/blog/service/PostService.java
@@ -1,0 +1,74 @@
+package umc.blog.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.blog.dto.PostDto;
+import umc.blog.dto.PostEditDto;
+import umc.blog.entity.Post;
+import umc.blog.exception.InputValidateException;
+import umc.blog.exception.TargetNotFoundException;
+import umc.blog.repository.PostRepository;
+
+@Service
+public class PostService {
+    private final PostRepository postRepository;
+
+    @Autowired
+    public PostService(PostRepository postRepository) {
+        this.postRepository = postRepository;
+    }
+
+    // 특정 글 조회 (id)
+    public Post findOne(Long id) {
+        return postRepository.findById(id).orElseThrow(() -> new TargetNotFoundException("target not found"));
+    }
+
+    // 글 생성
+    @Transactional
+    public Post write(PostDto postDto) {
+        validatePostDtoInput(postDto);
+
+        Post newPost = Post.builder().
+                writer("익명"). // 원래 FK이기 때문에 숫자를 정의하는 게 좋지만 익명임을 나타내기 위해 이렇게 설정
+                        title(postDto.getTitle()).
+                content(postDto.getContent()).
+                build();
+
+        postRepository.save(newPost);
+
+        return newPost;
+    }
+
+    // 글 수정
+    @Transactional
+    public Post edit(Long id, PostEditDto editDto) {
+        validatePostEditDtoInput(editDto);
+
+        Post targetPost = postRepository.findById(id).orElseThrow(
+                () -> new TargetNotFoundException("target not found")
+        );
+
+        targetPost.setTitle(editDto.getTitle());
+        targetPost.setContent(editDto.getContent());
+
+        return targetPost;
+    }
+
+    // 글 삭제
+    @Transactional
+    public void delete(Long id) {
+        postRepository.findById(id).orElseThrow(() -> new TargetNotFoundException("target not found"));
+        postRepository.deleteById(id);
+    }
+
+    public void validatePostEditDtoInput(PostEditDto editDto) {
+        if (editDto.getTitle() == null || editDto.getContent() == null)
+            throw new InputValidateException("validation error");
+    }
+
+    public void validatePostDtoInput(PostDto postDto) {
+        if (postDto.getTitle() == null || postDto.getContent() == null)
+            throw new InputValidateException("validation error");
+    }
+}

--- a/데이빗_최현준/7주차 미션/blog/src/main/resources/application.yml
+++ b/데이빗_최현준/7주차 미션/blog/src/main/resources/application.yml
@@ -1,0 +1,22 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/umc_blog?serverTimezone=Asia/Seoul
+    username: root
+    password: choi1209
+  jpa:
+    hibernate:
+      ddl-auto: create # DDL setting (create, update..)
+    properties:
+      hibernate:
+        show_sql: true # hibernate query show
+        format_sql: true # query prettier
+        use_sql_comments: true # show query comment
+    database-platform: org.hibernate.dialect.MySQLDialect # database select setting
+logging:
+  level:
+    org:
+      hibernate:
+        type:
+          descriptor:
+            sql: trace # hibernate value inner "?" showing

--- a/데이빗_최현준/7주차 미션/blog/src/test/java/umc/blog/BlogApplicationTests.java
+++ b/데이빗_최현준/7주차 미션/blog/src/test/java/umc/blog/BlogApplicationTests.java
@@ -1,0 +1,28 @@
+package umc.blog;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import javax.sql.DataSource;
+
+@SpringBootTest
+class BlogApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+	@Bean
+	@Profile("test")
+	public DataSource dataSource() {
+		DriverManagerDataSource dataSource = new DriverManagerDataSource();
+		dataSource.setDriverClassName("org.h2.Driver");
+		dataSource.setUrl("jdbc:h2:mem:db;DB_CLOSE_DELAY=-1");
+		dataSource.setUsername("min");
+		dataSource.setPassword("");
+		return dataSource;
+	}
+}

--- a/데이빗_최현준/7주차 미션/blog/src/test/java/umc/blog/PostTest.java
+++ b/데이빗_최현준/7주차 미션/blog/src/test/java/umc/blog/PostTest.java
@@ -1,0 +1,226 @@
+package umc.blog;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.transaction.annotation.Transactional;
+import umc.blog.dto.PostDto;
+import umc.blog.dto.PostEditDto;
+import umc.blog.entity.Post;
+import umc.blog.exception.InputValidateException;
+import umc.blog.exception.TargetNotFoundException;
+import umc.blog.repository.PostRepository;
+import umc.blog.service.PostService;
+
+import javax.sql.DataSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+public class PostTest {
+    private final DataSource dataSource;
+    private final PostRepository postRepository;
+    private final PostService postService;
+
+    @Autowired
+    public PostTest(DataSource dataSource, PostRepository postRepository, PostService postService) {
+        this.dataSource = dataSource;
+        this.postRepository = postRepository;
+        this.postService = postService;
+    }
+
+    @Test
+    @DisplayName("글 생성 및 저장 테스트")
+    void save() {
+        // given
+        Post newPost1 = Post.builder().writer("익명").title("첫 번째 글").content("첫 번째 글 내용").build();
+        Post newPost2 = Post.builder().writer("익명").title("두 번째 글").content("두 번째 글 내용").build();
+        Post newPost3 = Post.builder().writer("익명").title("세 번째 글").content("세 번째 글 내용").build();
+
+        // when
+        postRepository.save(newPost1);
+        postRepository.save(newPost2);
+        postRepository.save(newPost3);
+        List<Post> result = postRepository.findAll();
+
+        // then
+        assertThat(result.size()).isEqualTo(3);
+        assertThat(result.contains(newPost1)).isTrue();
+        assertThat(result.contains(newPost2)).isTrue();
+        assertThat(result.contains(newPost3)).isTrue();
+    }
+
+    @Test
+    @DisplayName("글 생성 및 저장 테스트 - Service를 사용")
+    void saveUsingService() {
+        // given
+        PostDto postDto = new PostDto();
+        postDto.setTitle("첫 번째 글");
+        postDto.setContent("첫 번째 글 내용");
+
+        // when
+        Post wrotePost = postService.write(postDto);
+        Post targetPost = postRepository.findById(wrotePost.getId()).orElseThrow(
+                () -> new TargetNotFoundException("target not found")
+        );
+
+        // then
+        assertThat(wrotePost.getId()).isEqualTo(1);
+        assertThat(targetPost).isEqualTo(wrotePost);
+    }
+
+    @Test
+    @DisplayName("글 생성 및 저장 테스트 - 실패 케이스 (Service 사용)")
+    void saveFail() {
+        // given
+        PostDto postDto = new PostDto();
+        postDto.setTitle(null);
+        postDto.setContent("첫 번째 글 내용");
+
+        // when & then
+        assertThrows(InputValidateException.class, () -> {
+            postService.write(postDto);
+        });
+        assertThrows(NullPointerException.class, () -> {
+            postService.write(null);
+        });
+    }
+
+    @Test
+    @DisplayName("글 수정 테스트")
+    void edit() {
+        // given
+        Post newPost1 = Post.builder().writer("익명").title("첫 번째 글").content("첫 번째 글 내용").build();
+
+        // when
+        postRepository.save(newPost1);
+        newPost1.setTitle("첫 번째 글 (수정)");
+        Post targetPost = postRepository.findById(newPost1.getId()).orElseThrow(
+                () -> new TargetNotFoundException("target not found"));
+
+        // then
+        assertThat(targetPost.getTitle()).isEqualTo("첫 번째 글 (수정)");
+    }
+
+    @Test
+    @DisplayName("글 수정 테스트 - Service를 사용")
+    void editUsingService() {
+        // given
+        PostDto postDto = new PostDto();
+        postDto.setTitle("첫 번째 글");
+        postDto.setContent("첫 번째 글 내용");
+
+        // when
+        Post targetPost = postService.write(postDto);
+        PostEditDto editDto = new PostEditDto();
+        editDto.setTitle("첫 번째 글 (수정)");
+        editDto.setContent("첫 번째 글 내용");
+        postService.edit(targetPost.getId(), editDto);
+
+        // then
+        assertThat(targetPost.getTitle()).isEqualTo("첫 번째 글 (수정)");
+    }
+
+    @Test
+    @DisplayName("글 수정 테스트 - 실패 케이스 (Service 사용)")
+    void editFail() {
+        // given
+        PostDto postDto = new PostDto();
+        postDto.setTitle("첫 번째 글");
+        postDto.setContent("첫 번째 글 내용");
+
+        // when
+        Post targetPost = postService.write(postDto);
+        PostEditDto editDto = new PostEditDto();
+        editDto.setTitle(null);
+        editDto.setContent("첫 번째 글 내용");
+
+        PostEditDto successEditDto = new PostEditDto();
+        successEditDto.setContent("첫 번째 글 (수정)");
+        successEditDto.setTitle("첫 번째 글 내용");
+
+        // then
+        assertThrows(InputValidateException.class, () -> {
+            postService.edit(targetPost.getId(), editDto);
+        });
+        assertThrows(InputValidateException.class, () -> {
+            postService.edit(10000L, editDto);
+        });
+        assertThrows(TargetNotFoundException.class, () -> {
+            postService.edit(10000L, successEditDto);
+        });
+        assertThrows(InvalidDataAccessApiUsageException.class, () -> {
+            postService.edit(null, successEditDto);
+        });
+        assertThrows(NullPointerException.class, () -> {
+            postService.edit(targetPost.getId(), null);
+        });
+    }
+
+    @Test
+    @DisplayName("글 삭제 테스트")
+    void delete() {
+        // given
+        Post newPost1 = Post.builder().writer("익명").title("첫 번째 글").content("첫 번째 글 내용").build();
+        Post newPost2 = Post.builder().writer("익명").title("두 번째 글").content("두 번째 글 내용").build();
+        Post newPost3 = Post.builder().writer("익명").title("세 번째 글").content("세 번째 글 내용").build();
+
+        // when
+        postRepository.save(newPost1);
+        postRepository.save(newPost2);
+        postRepository.save(newPost3);
+        postRepository.deleteById(newPost1.getId());
+        List<Post> result = postRepository.findAll();
+
+        // then
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result.contains(newPost1)).isFalse();
+        assertThat(result.contains(newPost2)).isTrue();
+        assertThat(result.contains(newPost3)).isTrue();
+        assertThat(postRepository.findById(newPost1.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("글 삭제 테스트 - Service를 사용")
+    void deleteUsingService() {
+        // given
+        PostDto newPostDto = new PostDto();
+        newPostDto.setTitle("첫 번째 글");
+        newPostDto.setContent("첫 번째 글 내용");
+
+        Post targetPost = postService.write(newPostDto);
+
+        // when
+        postService.delete(targetPost.getId());
+
+        // then
+        assertThrows(TargetNotFoundException.class, () -> {
+            postService.findOne(targetPost.getId());
+        });
+    }
+
+    @Test
+    @DisplayName("글 삭제 테스트 - 실패 케이스 (Service 사용)")
+    void deleteFail() {
+        // given
+        PostDto newPostDto = new PostDto();
+        newPostDto.setTitle("첫 번째 글");
+        newPostDto.setContent("첫 번째 글 내용");
+
+        postService.write(newPostDto);
+
+        // when
+        assertThrows(TargetNotFoundException.class, () -> {
+            postService.delete(10000L);
+        });
+        assertThrows(InvalidDataAccessApiUsageException.class, () -> {
+            postService.delete(null);
+        });
+    }
+}

--- a/데이빗_최현준/7주차 미션/blog/src/test/resources/application.yml
+++ b/데이빗_최현준/7주차 미션/blog/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: test

--- a/데이빗_최현준/7주차 미션/blog/src/test/resources/schema.sql
+++ b/데이빗_최현준/7주차 미션/blog/src/test/resources/schema.sql
@@ -1,0 +1,8 @@
+drop table if exists post;
+create table post (
+    post_id bigint not null auto_increment,
+    content varchar(255),
+    title varchar(255),
+    writer varchar(255),
+    primary key (post_id)
+);

--- a/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/TripApplication.java
+++ b/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/TripApplication.java
@@ -1,0 +1,13 @@
+package umc.trip;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TripApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(TripApplication.class, args);
+	}
+
+}

--- a/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/controller/TripController.java
+++ b/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/controller/TripController.java
@@ -1,0 +1,76 @@
+package umc.trip.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import umc.trip.dto.TripDto;
+import umc.trip.dto.TripEditDto;
+import umc.trip.exception.ExceptionResponse;
+import umc.trip.exception.InputValidateException;
+import umc.trip.exception.TargetNotFoundException;
+import umc.trip.service.TripService;
+
+import java.util.HashMap;
+
+@RestController
+@RequestMapping("/trip")
+public class TripController {
+
+    private final TripService tripService;
+
+    @Autowired
+    public TripController(TripService tripService) {
+        this.tripService = tripService;
+    }
+
+    // 여행 정보 글 생성
+    @PostMapping
+    ResponseEntity<?> upload(@RequestBody TripDto tripDto) {
+        try {
+            return ResponseEntity.ok(tripService.upload(tripDto));
+        } catch (InputValidateException e) {
+            return errorMessage(e.getMessage());
+        }
+    }
+
+    // 여행 정보 글 조회
+    @GetMapping("/{id}")
+    ResponseEntity<?> find(@PathVariable Long id) {
+        try {
+            return ResponseEntity.ok(tripService.read(id));
+        } catch (TargetNotFoundException e) {
+            return errorMessage(e.getMessage());
+        }
+    }
+
+    // 여행 정보 글 수정
+    @PutMapping("/{id}")
+    ResponseEntity<?> edit(@PathVariable Long id, @RequestBody TripEditDto editDto) {
+        try {
+            return ResponseEntity.ok(tripService.edit(id, editDto));
+        } catch (TargetNotFoundException | InputValidateException e) {
+            return errorMessage(e.getMessage());
+        }
+    }
+
+    // 여행 정보 글 삭제
+    @DeleteMapping("/{id}")
+    ResponseEntity<?> delete(@PathVariable Long id) {
+        try {
+            tripService.delete(id);
+            return ResponseEntity.status(HttpStatus.OK).body(
+                    new HashMap<String, String>() {{
+                        put("message", "삭제 완료");
+                    }});
+        } catch (TargetNotFoundException e) {
+            return errorMessage(e.getMessage());
+        }
+    }
+
+    private ResponseEntity<ExceptionResponse> errorMessage(String message) {
+        ExceptionResponse exceptionResponse = new ExceptionResponse(message);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(exceptionResponse);
+    }
+}

--- a/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/dto/TripDto.java
+++ b/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/dto/TripDto.java
@@ -1,0 +1,17 @@
+package umc.trip.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TripDto {
+    private String nation;
+    private String title;
+    private String content;
+    private Integer score;
+}

--- a/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/dto/TripEditDto.java
+++ b/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/dto/TripEditDto.java
@@ -1,0 +1,16 @@
+package umc.trip.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TripEditDto {
+    private String nation;
+    private String title;
+    private String content;
+}

--- a/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/entity/Trip.java
+++ b/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/entity/Trip.java
@@ -1,0 +1,29 @@
+package umc.trip.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class Trip {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trip_id")
+    private Long id;
+
+    private String writer;
+
+    private String nation;
+
+    private String title;
+
+    private String content;
+
+    private Long view;
+
+    private Integer score;
+}

--- a/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/exception/ExceptionResponse.java
+++ b/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/exception/ExceptionResponse.java
@@ -1,0 +1,13 @@
+package umc.trip.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ExceptionResponse {
+
+    private String message;
+}

--- a/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/exception/InputValidateException.java
+++ b/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/exception/InputValidateException.java
@@ -1,0 +1,10 @@
+package umc.trip.exception;
+
+public class InputValidateException extends RuntimeException {
+    public InputValidateException() {
+    }
+
+    public InputValidateException(String message) {
+        super(message);
+    }
+}

--- a/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/exception/TargetNotFoundException.java
+++ b/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/exception/TargetNotFoundException.java
@@ -1,0 +1,10 @@
+package umc.trip.exception;
+
+public class TargetNotFoundException extends RuntimeException {
+    public TargetNotFoundException() {
+    }
+
+    public TargetNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/repository/TripRepository.java
+++ b/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/repository/TripRepository.java
@@ -1,0 +1,7 @@
+package umc.trip.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.trip.entity.Trip;
+
+public interface TripRepository extends JpaRepository<Trip, Long> {
+}

--- a/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/service/TripService.java
+++ b/데이빗_최현준/7주차 미션/trip/src/main/java/umc/trip/service/TripService.java
@@ -1,0 +1,90 @@
+package umc.trip.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.trip.dto.TripDto;
+import umc.trip.dto.TripEditDto;
+import umc.trip.entity.Trip;
+import umc.trip.exception.InputValidateException;
+import umc.trip.exception.TargetNotFoundException;
+import umc.trip.repository.TripRepository;
+
+@Service
+@Transactional
+public class TripService {
+
+    private final TripRepository tripRepository;
+
+    public TripService(TripRepository tripRepository) {
+        this.tripRepository = tripRepository;
+    }
+
+    // 여행 정보 생성
+    public Trip upload(TripDto tripDto) {
+        validateTripDto(tripDto);
+
+        Trip newTrip = Trip.builder()
+                .writer("익명")
+                .nation(tripDto.getNation())
+                .title(tripDto.getTitle())
+                .content(tripDto.getContent())
+                .view(0L)
+                .score(tripDto.getScore())
+                .build();
+
+        tripRepository.save(newTrip);
+
+        return newTrip;
+    }
+
+    // 여행 정보 조회
+    public Trip read(Long id) {
+        Trip targetTrip = tripRepository.findById(id).orElseThrow(
+                () -> new TargetNotFoundException("target not found")
+        );
+
+        targetTrip.setView(targetTrip.getView() + 1);
+
+        return targetTrip;
+    }
+
+    // 여행 정보 수정
+    public Trip edit(Long id, TripEditDto editDto) {
+        validateTripEditDto(editDto);
+
+        Trip targetTrip = tripRepository.findById(id).orElseThrow(
+                () -> new TargetNotFoundException("target not found")
+        );
+
+        targetTrip.setNation(editDto.getNation());
+        targetTrip.setTitle(editDto.getTitle());
+        targetTrip.setContent(editDto.getContent());
+
+        return targetTrip;
+    }
+
+    // 여행 정보 삭제
+    public void delete(Long id) {
+        tripRepository.findById(id).orElseThrow(
+                () -> new TargetNotFoundException("target not found")
+        );
+        tripRepository.deleteById(id);
+    }
+
+    private void validateTripDto(TripDto tripDto) {
+        if (tripDto.getNation() == null ||
+            tripDto.getTitle() == null ||
+            tripDto.getContent() == null ||
+            tripDto.getScore() == null ||
+            tripDto.getScore() < 0 ||
+            tripDto.getScore() > 10)
+            throw new InputValidateException("validation error");
+    }
+
+    private void validateTripEditDto(TripEditDto editDto) {
+        if (editDto.getNation() == null ||
+            editDto.getTitle() == null ||
+            editDto.getContent() == null)
+            throw new InputValidateException("validation error");
+    }
+}

--- a/데이빗_최현준/7주차 미션/trip/src/test/java/umc/trip/TripApplicationTests.java
+++ b/데이빗_최현준/7주차 미션/trip/src/test/java/umc/trip/TripApplicationTests.java
@@ -1,0 +1,13 @@
+package umc.trip;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class TripApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}


### PR DESCRIPTION
- 블로그 CRUD API 구현
- 커스텀 주제 CRUD API 구현

## 작업 내용 👨🏻‍💻

- [x] 블로그 CRUD API 완성하기 
- [x] 커스텀 주제 CRUD API 완성하기 
- [x] 포스트맨을 이용한 통신 결과 보이기

## To Reviewers 💬
- 이슈를 만들고 PR을 보내는 식으로 하다보니 UMC 레포에서 작업하질 않고 개인 레포지토리에서 진행했었습니다. 그렇기 때문에 실제 동작하진 않고, 작업한 결과물에 대한 파일만 제출하겠습니다.
- 첫 번째 미션인 블로그 API에 대해서는 [이곳](https://github.com/devholic22/UMC_blog)에서 확인하실 수 있습니다. 다만 특정 조건에 맞는 게시물 목록을 조회하는 것을 하지 못했기 때문에 아직 조회는 특정 id를 가진 게시물을 조회하는 것 밖에 하지 못했습니다. API 문서는 [이곳](https://umc-blog-api.gitbook.io/umc-blog-api/)입니다. 추가로 API 문서 (깃북)를 만들면서 사용법을 [이곳](https://velog.io/@devholic22/GitBook-%EC%82%AC%EC%9A%A9%EB%B2%95-%EC%A0%95%EB%A6%AC)에 정리하였습니다.
- 두 번째 미션인 커스텀 API는 여행과 관련된 것을 하였습니다. 시간상 블로그 때 처럼 테스트 코드와 API 문서를 만드는 작업은 하지 못했습니다. 마찬가지로 조회는 특정 id를 가진 정보 글을 조회하는 것만 구현하였습니다. 다만 블로그 때와 다른 점은, 조회 수를 추가하였습니다. 즉, 한 정보 글을 조회한다면 조회 수가 증가되도록 하였으며, 그렇기에 `@GetMapping`임에도 `@Transactional` 어노테이션을 붙였습니다. (따라서 서비스 단위에 해당 어노테이션을 붙였습니다.) 작업 레포지토리는 [이곳](https://github.com/devholic22/UMC_trip)입니다.
  <img width="531" alt="스크린샷 2023-05-17 오후 2 20 06" src="https://github.com/UMC-MJU/4th_Server_B/assets/90085154/0018181c-6eb9-410b-8a21-cc0b1ed12815">
- 첫 번째 미션과 두 번째 미션에 대한 포스트맨 결과들은 노션 페이지에 작성하였습니다.

## Reference 🔬 
- 개인적으로 참여했던 넘블 API 프로젝트의 구조를 참고하여 진행하였고, 챌린지 1등을 한 분의 작업 진행 방법을 참고하였습니다.
  - [프로젝트](https://github.com/devholic22/numble_insta)
  - [챌린지 1등](https://github.com/Kwoojong/Instagram-Spring)
